### PR TITLE
expose `read_buffer_size` in parts

### DIFF
--- a/lib/http_multipart_formdata.ml
+++ b/lib/http_multipart_formdata.ml
@@ -348,7 +348,7 @@ let unconsumed reader = reader.unconsumed
 
 (* Non streaming *)
 
-let parts boundary body =
+let parts ?(read_buffer_size = 10) boundary body =
   let rec read_parts reader parts =
     read reader
     |> function
@@ -374,7 +374,7 @@ let parts boundary body =
     | _ -> assert false
   in
   let reader =
-    reader ~read_buffer_size:10 boundary (`Cstruct (Cstruct.of_string body))
+    reader ~read_buffer_size boundary (`Cstruct (Cstruct.of_string body))
   in
   read_parts reader (Queue.create ())
 

--- a/lib/http_multipart_formdata.mli
+++ b/lib/http_multipart_formdata.mli
@@ -89,11 +89,12 @@ val unconsumed : reader -> Cstruct.t
     size. *)
 
 val parts :
-     boundary
+  ?read_buffer_size:int
+  -> boundary
   -> string
   -> ((field_name * (part_header * part_body)) list, string) result
-(** [parts boundary http_body] returns a list of HTTP multipart parts parsed in
-    [http_body].
+(** [parts ?read_buffer_size boundary http_body] returns a list of HTTP
+    multipart parts parsed in [http_body].
 
     The returned parts list is keyed to a form field name so that one can do:
 


### PR DESCRIPTION
When dealing with slightly large files (>1MB), the reader loop becomes unnecessary slow. Increasing the buffer size from the default 10 to something larger substantially speeds up processing.

I understand the non-blocking API can be used to provide a custom buffer size, but I think it should be possible to do this for the blocking version too when the expected inputs safely fit in memory.

Also, any reason why the `read_buffer_size` values are different for `parts` and `reader`? Why not just have one default?